### PR TITLE
Clarify Add Member to Channel Hint Text

### DIFF
--- a/mattermost-webapp/en.json
+++ b/mattermost-webapp/en.json
@@ -3591,7 +3591,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "You can add {num, number} more",
+  "multiselect.numRemaining": "You can add up to {num, number} people at a time",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/mattermost-webapp/en.json
+++ b/mattermost-webapp/en.json
@@ -3591,7 +3591,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "You can add {num, number} more at a time",
+  "multiselect.numRemaining": "Up to {max} can be added at a time. You have {num, number} remaining.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/mattermost-webapp/en.json
+++ b/mattermost-webapp/en.json
@@ -3591,7 +3591,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "You can add up to {num, number} people at a time",
+  "multiselect.numRemaining": "You can add {num, number} more in this batch",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/mattermost-webapp/en.json
+++ b/mattermost-webapp/en.json
@@ -3591,7 +3591,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "Up to {max} can be added at a time. You have {num, number} remaining.",
+  "multiselect.numRemaining": "Up to {max, number} can be added at a time. You have {num, number} remaining.",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",

--- a/mattermost-webapp/en.json
+++ b/mattermost-webapp/en.json
@@ -3591,7 +3591,7 @@
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
   "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
-  "multiselect.numRemaining": "You can add {num, number} more in this batch",
+  "multiselect.numRemaining": "You can add {num, number} more at a time",
   "multiselect.placeholder": "Search for people",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",
   "multiselect.selectTeams": "Use ↑↓ to browse, ↵ to select.",


### PR DESCRIPTION
When adding members to a channel, the existing hint text ambiguously suggests that a maximum of 20 members can be added to a given channel. Updated hint text to note that users can add up to 20 members at a time to the channel.